### PR TITLE
Fix Firefox --headless config missing

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -19,5 +19,8 @@ module.exports = {
         '--window-size=1440,900',
       ].filter(Boolean),
     },
+    Firefox: {
+      ci: ['--headless'],
+    },
   },
 };


### PR DESCRIPTION
Missing configuration for headless setup for Firefox CI runs from #30.